### PR TITLE
chore: package.json engines 필드 제거

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "start": "next start",
     "lint": "next lint"
   },
-  "engines": {
-    "node": ">=20.0.0"
-  },
   "dependencies": {
     "@supabase/supabase-js": "^2.89.0",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
Vercel Project Settings의 Node.js 버전(24.x)을 따르도록 변경 "Project Setting overridden by package.json" 경고 해소